### PR TITLE
Fixing tests, fixes #31

### DIFF
--- a/src/whs/yourchoice/client/Client.java
+++ b/src/whs/yourchoice/client/Client.java
@@ -19,12 +19,14 @@ import java.net.Socket;
 public class Client {
 	
 	// Variables storing information about the servers socket
-	Socket serverSocket;
-	String host = "127.0.0.1";
-	int port = 1138;
+	protected Socket serverSocket;
+	private String host = "127.0.0.1";
+	private int port = 1138;
+	private ObjectOutputStream outputToServer = null;
+	private ObjectInputStream inputFromServer = null;
 	
 	// Variable assigned by the server to identify the client
-	int iD = -1;
+	private int iD = -1;
 	
 	
 	/**
@@ -38,6 +40,8 @@ public class Client {
 		try {			
 			serverSocket = new Socket(host, port);
 			System.out.println("Connected to Server, host: " + host + ",port: " + port);
+			createOutputStream();
+			createInputStream();
 			receiveID();
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
@@ -52,6 +56,8 @@ public class Client {
 	protected void closeSocket() {
 		
 		try {
+			outputToServer.close();
+			inputFromServer.close();
 			serverSocket.close();
 			System.out.println("Socket successfully closed \n");
 		} catch (IOException e) {
@@ -61,6 +67,14 @@ public class Client {
 		
 	}
 
+	protected void createOutputStream() throws IOException {
+		// Create an object stream to send to server
+		System.out.println("(CLIENT) Creating output stream");
+		outputToServer = new ObjectOutputStream(serverSocket.getOutputStream());
+		System.out.println("(CLIENT) Created output stream");
+		outputToServer.flush();
+	}
+	
 	/**
 	 * Method to send an object to the server. 
 	 * A connection must be made prior to using this method. 
@@ -69,17 +83,21 @@ public class Client {
 	 * @throws IOException	-	Throws an exception if not connected to the server.
 	 */
 	protected void sendData(Object itemToSend) throws IOException {
-		
-		ObjectOutputStream outputToServer = null;
-
-		// Create an object stream to send to server
-		outputToServer = new ObjectOutputStream(serverSocket.getOutputStream());
-		
 		// Write the object to the server
 		outputToServer.writeObject(itemToSend);
 		
 	}
 
+	/**
+	 * @throws IOException
+	 */
+	protected void createInputStream() throws IOException {
+		System.out.println("(CLIENT) Creating input stream");
+		// Create an input stream from the connected server		
+		inputFromServer = new ObjectInputStream(serverSocket.getInputStream());
+		System.out.println("(CLIENT) Created input stream");
+	}
+	
 	/**
 	 * Method to receive data from the server.
 	 * A connection must be made prior to using this method.
@@ -88,12 +106,6 @@ public class Client {
 	 * @throws IOException	-	Throws an exception if not connected to the server.
 	 */
 	protected Object receiveData() throws IOException {
-		
-		ObjectInputStream inputFromServer = null;
-				
-		// Create an input stream from the connected server		
-		inputFromServer = new ObjectInputStream(serverSocket.getInputStream());
-		
 		// Return the object received from the server
 		try {
 			return inputFromServer.readObject();

--- a/src/whs/yourchoice/client/Client.java
+++ b/src/whs/yourchoice/client/Client.java
@@ -1,8 +1,3 @@
-/**
- * Client.java		v0.7 28/02/2016
- * 
- * 
- */
 package whs.yourchoice.client;
 
 import java.io.IOException;
@@ -14,14 +9,12 @@ import java.net.Socket;
  * Class for the client's back end handling communications to the server 
  * 
  * @author		user1092, guest501
- * @version		v0.7 28/02/2016
+ * @version		v0.8 06/04/2016
  */
 public class Client {
 	
 	// Variables storing information about the servers socket
 	protected Socket serverSocket;
-	private String host = "127.0.0.1";
-	private int port = 1138;
 	private ObjectOutputStream outputToServer = null;
 	private ObjectInputStream inputFromServer = null;
 	
@@ -31,11 +24,11 @@ public class Client {
 	
 	/**
 	 * Method to open socket, in order to connect to the server. 
+	 * 
 	 * @param host - The socket's host number
 	 * @param port - The socket's port number
 	 */
 	protected void openSocket(String host, int port) {
-	
 		// Connect to the server	
 		try {			
 			serverSocket = new Socket(host, port);
@@ -50,11 +43,11 @@ public class Client {
 		}
 	}
 
+	
 	/**
 	 * Method to close socket, in order to disconnect from the server. 
 	 */
 	protected void closeSocket() {
-		
 		try {
 			outputToServer.close();
 			inputFromServer.close();
@@ -67,13 +60,15 @@ public class Client {
 		
 	}
 
-	protected void createOutputStream() throws IOException {
+	
+	private void createOutputStream() throws IOException {
 		// Create an object stream to send to server
 		System.out.println("(CLIENT) Creating output stream");
 		outputToServer = new ObjectOutputStream(serverSocket.getOutputStream());
 		System.out.println("(CLIENT) Created output stream");
 		outputToServer.flush();
 	}
+	
 	
 	/**
 	 * Method to send an object to the server. 
@@ -85,18 +80,19 @@ public class Client {
 	protected void sendData(Object itemToSend) throws IOException {
 		// Write the object to the server
 		outputToServer.writeObject(itemToSend);
-		
 	}
 
+	
 	/**
 	 * @throws IOException
 	 */
-	protected void createInputStream() throws IOException {
+	private void createInputStream() throws IOException {
 		System.out.println("(CLIENT) Creating input stream");
 		// Create an input stream from the connected server		
 		inputFromServer = new ObjectInputStream(serverSocket.getInputStream());
 		System.out.println("(CLIENT) Created input stream");
 	}
+	
 	
 	/**
 	 * Method to receive data from the server.
@@ -120,6 +116,7 @@ public class Client {
 		}
 	}
 	
+	
 	/**
 	 * Method to receive an ID should be called once the connection to the server has been made.
 	 */
@@ -139,6 +136,7 @@ public class Client {
 		}
 	}
 
+	
 	/**
 	 * Method to retrieve the ID that has been assigned by the server.
 	 * 
@@ -147,4 +145,6 @@ public class Client {
 	protected int getID() {
 		return iD;
 	}
+	
+	
 }

--- a/src/whs/yourchoice/client/ClientInterfacer.java
+++ b/src/whs/yourchoice/client/ClientInterfacer.java
@@ -1,8 +1,3 @@
-/**
- * ClientInterfacer.java		v0.5 28/02/2016
- * 
- * 
- */
 package whs.yourchoice.client;
 
 import java.io.IOException;
@@ -42,7 +37,7 @@ public class ClientInterfacer {
 	public void closeSocket() {
 		client.closeSocket();
 	}
-	
+		
 	/**
 	 * Method to send an object to the server. 
 	 * A connection must be made prior to using this method. 
@@ -53,7 +48,7 @@ public class ClientInterfacer {
 	public void sendData(Object itemToSend) throws IOException {
 		client.sendData(itemToSend);
 	}
-	
+		
 	/**
 	 * Method to receive data from the server.
 	 * A connection must be made prior to using this method.

--- a/src/whs/yourchoice/client/ClientTests.java
+++ b/src/whs/yourchoice/client/ClientTests.java
@@ -64,9 +64,11 @@ public class ClientTests {
 	 */
 	@After
 	public void closeSockets() {
-		client.closeSocket();
+		//client.closeSocket();
 		
 		server.closeSocket();
+		
+		client.closeSocket();
 	}
 		
 	

--- a/src/whs/yourchoice/client/ClientTests.java
+++ b/src/whs/yourchoice/client/ClientTests.java
@@ -1,9 +1,3 @@
-/**
- * ClientTests.java		v0.6 23/02/2016
- * 
- * 
- */
-
 package whs.yourchoice.client;
 
 import static org.junit.Assert.*;
@@ -12,6 +6,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import whs.yourchoice.server.ServerInterfacer;
@@ -22,7 +17,7 @@ import whs.yourchoice.server.ServerInterfacer;
  * NOT FOR RELEASE!
  * 
  * @author		user1092, guest501
- * @version		v0.6 23/02/2016
+ * @version		v0.7 06/04/2016
  */
 public class ClientTests {
 
@@ -43,6 +38,7 @@ public class ClientTests {
 	ObjectInputStream inputStream = null;
 	Object itemReceived = null;
 	
+	
 	/**
 	 * Before every test, a server should be instantiated and sockets opened then
 	 * wait for a clients connection.
@@ -57,6 +53,7 @@ public class ClientTests {
 		client = new Client();
 		client.openSocket(host, port);
 	}
+	
 	
 	/**
 	 * After every test, the client's sockets should close
@@ -75,7 +72,7 @@ public class ClientTests {
 	/**
 	 * Test that a client can send data on an open socket.
 	 */
-	@Test 
+	@Test
 	public void clientShouldSendDataOnAnOpenSocket() {
 		Object itemToSend = "HEYYY";
 		
@@ -83,10 +80,10 @@ public class ClientTests {
 		Thread listenThread = new Thread("Listen") {
 			public void run() {
 				try {
-					itemReceived = server.receiveData(client.getID());
-				} catch (ClassNotFoundException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					// Can no longer do as server listens to client as soon as it connects
+					//itemReceived = server.receiveData(client.getID());
+					// Now Server will pass back the object as soon as it receives it
+					itemReceived = client.receiveData();
 				} catch (IOException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
@@ -109,6 +106,7 @@ public class ClientTests {
 		assertEquals(itemToSend, itemReceived);
 	}
 
+	
 	/**
 	 * Test that a client can receive data from an open socket.
 	 */
@@ -141,13 +139,16 @@ public class ClientTests {
 		
 	}
 	
+	//TODO
 	/**
 	 * 
 	 */
-//	@Test
-//	public void clientShouldReceieveModuleList() {
-//		fail("Not Implemented");
-//	}
+	@Ignore("To be implemented")
+	@Test
+	public void clientShouldReceieveModuleList() {
+		fail("Not Implemented");
+	}
+	
 	
 	/**
 	 * Test that the client gets assigned the ID 0 as it should be the only client connected.
@@ -158,4 +159,5 @@ public class ClientTests {
 		assertEquals(0, client.getID());
 	}
 
+	
 }

--- a/src/whs/yourchoice/server/ConnectedClient.java
+++ b/src/whs/yourchoice/server/ConnectedClient.java
@@ -1,9 +1,3 @@
-/**
- * ConnectedClient.java		v0.2 23/02/2016
- * 
- * 
- */
-
 package whs.yourchoice.server;
 
 import java.io.IOException;
@@ -15,7 +9,7 @@ import java.net.Socket;
  * Class for storing information about the clients that are connected to the server.
  * 
  * @author		user1092, guest501
- * @version		v0.2 23/02/2016
+ * @version		v0.3 06/04/2016
  */
 public class ConnectedClient {
 	
@@ -24,16 +18,17 @@ public class ConnectedClient {
 	private ObjectOutputStream outputToClient = null;
 	private ObjectInputStream inputFromClient = null;
 
+	
 	/**
 	 * Method to determine if the client's socket is connected
 	 * 
 	 * @return clientSocket.isConnected()	-	Returns true if connected, else returns false.
 	 */
 	protected boolean socketIsConnected() {
-		//return clientSocket.isConnected();
 		return !clientSocket.isClosed();
 	}
 
+	
 	/**
 	 * Method to get the ID assigned to the client.
 	 * 
@@ -43,6 +38,7 @@ public class ConnectedClient {
 		return iD;
 	}
 
+	
 	/**
 	 * Method to set the ID of the client.
 	 * 
@@ -52,6 +48,7 @@ public class ConnectedClient {
 		this.iD = iD;
 	}
 
+	
 	/**
 	 * Method to get the socket assigned to the client.
 	 * 
@@ -61,6 +58,7 @@ public class ConnectedClient {
 		return clientSocket;
 	}
 
+	
 	/**
 	 * Method to set the socket assigned to the client.
 	 * 
@@ -69,6 +67,7 @@ public class ConnectedClient {
 	protected void setClientSocket(Socket clientSocket) {
 		this.clientSocket = clientSocket;
 	}
+	
 	
 	/**
 	 * Method to close the socket used to communicate to the connected client.
@@ -81,35 +80,50 @@ public class ConnectedClient {
 		clientSocket.close();
 	}
 
+	
 	/**
+	 * Method to get the output stream
+	 * 
 	 * @return the outputToClient
 	 */
 	protected ObjectOutputStream getOutputToClient() {
 		return outputToClient;
 	}
 
+	
 	/**
+	 * Method to create an output stream, to send data.
 	 * 
 	 * @throws IOException
 	 */
 	protected void createOutputToClient() throws IOException {
+		System.out.println("(SERVER) Creating ouput stream for client: " + iD);
 		outputToClient = new ObjectOutputStream(clientSocket.getOutputStream());
 		outputToClient.flush();
+		System.out.println("(SERVER) Created ouput stream for client: " + iD);
 	}
 
+	
 	/**
+	 * Method to get the input stream
+	 * 
 	 * @return the inputFromClient
 	 */
 	protected ObjectInputStream getInputFromClient() {
 		return inputFromClient;
 	}
 
+	
 	/**
+	 * Method to create an input stream, to receive data.
 	 * 
 	 * @throws IOException
 	 */
 	protected void createInputFromClient() throws IOException {
+		System.out.println("(SERVER) Creating input stream for client: " + iD);
 		inputFromClient = new ObjectInputStream(clientSocket.getInputStream());
+		System.out.println("(SERVER) Created input stream for client: " + iD);
 	}
 
+	
 }

--- a/src/whs/yourchoice/server/ConnectedClient.java
+++ b/src/whs/yourchoice/server/ConnectedClient.java
@@ -7,6 +7,8 @@
 package whs.yourchoice.server;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 /**
@@ -19,7 +21,8 @@ public class ConnectedClient {
 	
 	private int iD = -1; 
 	private Socket clientSocket = new Socket();
-	
+	private ObjectOutputStream outputToClient = null;
+	private ObjectInputStream inputFromClient = null;
 
 	/**
 	 * Method to determine if the client's socket is connected
@@ -73,7 +76,40 @@ public class ConnectedClient {
 	 * @throws IOException		Throws if the socket is already closed.
 	 */
 	protected void closeClientSocket() throws IOException {
+		inputFromClient.close();
+		outputToClient.close();
 		clientSocket.close();
+	}
+
+	/**
+	 * @return the outputToClient
+	 */
+	protected ObjectOutputStream getOutputToClient() {
+		return outputToClient;
+	}
+
+	/**
+	 * 
+	 * @throws IOException
+	 */
+	protected void createOutputToClient() throws IOException {
+		outputToClient = new ObjectOutputStream(clientSocket.getOutputStream());
+		outputToClient.flush();
+	}
+
+	/**
+	 * @return the inputFromClient
+	 */
+	protected ObjectInputStream getInputFromClient() {
+		return inputFromClient;
+	}
+
+	/**
+	 * 
+	 * @throws IOException
+	 */
+	protected void createInputFromClient() throws IOException {
+		inputFromClient = new ObjectInputStream(clientSocket.getInputStream());
 	}
 
 }

--- a/src/whs/yourchoice/server/Server.java
+++ b/src/whs/yourchoice/server/Server.java
@@ -61,7 +61,8 @@ public class Server {
 													currentClientNumber++) {
 				// Check if the client entry exists
 				if(null != clients[currentClientNumber]) {
-					// Check if the socket is connected 
+					System.out.println("Socket of client is open?: " + clients[currentClientNumber].socketIsConnected());
+					// Check if the socket is connected
 					if(clients[currentClientNumber].socketIsConnected()){
 						System.out.println("Closing socket of client: " + currentClientNumber);
 						clients[currentClientNumber].closeClientSocket();
@@ -112,6 +113,17 @@ public class Server {
 							
 							currentClient = acceptClientConnection(currentClient);
 							currentClient.setID(currentClientNumber);
+//							try {
+//								System.out.println("(SERVER) Creating ouput stream");
+//								currentClient.createOutputToClient();
+//								System.out.println("(SERVER) Created ouput stream");
+//								System.out.println("(SERVER) Creating input stream");
+//								currentClient.createInputFromClient();
+//								System.out.println("(SERVER) Created input stream");
+//							} catch (IOException e) {
+//								// TODO Auto-generated catch block
+//								e.printStackTrace();
+//							}
 							manageClient(currentClient, currentClientNumber);
 							
 							if(currentClientNumber < connectedClientsMaxNumber - 1){
@@ -126,8 +138,26 @@ public class Server {
 						}
 						// Attempt to accept client
 						currentClient = acceptClientConnection(currentClient);
-						currentClient.setID(currentClientNumber);	
+						currentClient.setID(currentClientNumber);
+//						try {
+//							System.out.println("(SERVER) Creating ouput stream");
+//							currentClient.createOutputToClient();
+//							System.out.println("(SERVER) Created ouput stream");
+//							System.out.println("(SERVER) Creating input stream");
+//							currentClient.createInputFromClient();
+//							System.out.println("(SERVER) Created input stream");
+//						} catch (IOException e) {
+//							// TODO Auto-generated catch block
+//							e.printStackTrace();
+//						}
 						manageClient(currentClient, currentClientNumber);
+						
+//						try {
+//							currentClient.closeClientSocket();
+//						} catch (IOException e) {
+//							// TODO Auto-generated catch block
+//							e.printStackTrace();
+//						}
 					}
 				}
 			}
@@ -161,6 +191,17 @@ public class Server {
 	 */
 	private void manageClient(ConnectedClient currentClient, int clientNumber) {
 		try {
+			try {
+				System.out.println("(SERVER) Creating ouput stream");
+				currentClient.createOutputToClient();
+				System.out.println("(SERVER) Created ouput stream");
+				System.out.println("(SERVER) Creating input stream");
+				currentClient.createInputFromClient();
+				System.out.println("(SERVER) Created input stream");
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
 			/*
 			 *  If entry in clients array doesn't exist create it 
 			 *  and accept then listen to client
@@ -203,23 +244,31 @@ public class Server {
 	 * @param clientID	- This is the ID of the client the data should be sent to.
 	 */
 	protected void sendData(Object itemToSend, int clientID) {
-		ObjectOutputStream outputToClient = null;
+//		ObjectOutputStream outputToClient = null;
+//		
+//		// Create an object stream to send to client
+//		try {
+//			outputToClient = new ObjectOutputStream(clients[clientID].getClientSocket().getOutputStream());
+//		} catch (IOException e) {
+//			// TODO Auto-generated catch block
+//			e.printStackTrace();
+//		}
+//		
+//		// Write the object to the client
+//		try {
+//			outputToClient.writeObject(itemToSend);
+//		} catch (IOException e) {
+//			// TODO Auto-generated catch block
+//			e.printStackTrace();
+//		}
 		
-		// Create an object stream to send to client
 		try {
-			outputToClient = new ObjectOutputStream(clients[clientID].getClientSocket().getOutputStream());
+			clients[clientID].getOutputToClient().writeObject(itemToSend);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		
-		// Write the object to the client
-		try {
-			outputToClient.writeObject(itemToSend);
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
 	}
 
 	/**
@@ -232,13 +281,14 @@ public class Server {
 	 * @throws ClassNotFoundException 
 	 */
 	protected Object receiveData(int clientID) throws IOException, ClassNotFoundException {
-		ObjectInputStream inputFromClient = null;
-				
-		// Create an input stream from the connected client
-		inputFromClient = new ObjectInputStream(clients[clientID].getClientSocket().getInputStream());
-		
-		// Return the object received from the client
-		return inputFromClient.readObject();
+//		ObjectInputStream inputFromClient = null;
+//				
+//		// Create an input stream from the connected client
+//		inputFromClient = new ObjectInputStream(clients[clientID].getClientSocket().getInputStream());
+//		
+//		// Return the object received from the client
+//		return inputFromClient.readObject();
+		return clients[clientID].getInputFromClient().readObject();
 	}
 	
 	/**
@@ -247,19 +297,33 @@ public class Server {
 	 * @param client - This is the client to be informed
 	 */
 	private void informThatServerFull(ConnectedClient client) {
-		ObjectOutputStream outputToClient = null;
+//		ObjectOutputStream outputToClient = null;
+//		
+//		// Create an object stream to send to client
+//		try {
+//			outputToClient = new ObjectOutputStream(client.getClientSocket().getOutputStream());
+//		} catch (IOException e) {
+//			// TODO Auto-generated catch block
+//			e.printStackTrace();
+//		}
+//		
+//		// Write the object to the client
+//		try {
+//			outputToClient.writeObject(-1);
+//		} catch (IOException e) {
+//			// TODO Auto-generated catch block
+//			e.printStackTrace();
+//		}
 		
-		// Create an object stream to send to client
 		try {
-			outputToClient = new ObjectOutputStream(client.getClientSocket().getOutputStream());
+			client.getOutputToClient().writeObject(-1);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		
-		// Write the object to the client
 		try {
-			outputToClient.writeObject(-1);
+			client.closeClientSocket();
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -274,9 +338,20 @@ public class Server {
 	private void listenToClient(final ConnectedClient client) {
 		Thread[] listenToClientThread;
 		listenToClientThread = new Thread[connectedClientsMaxNumber];
+		
+//		try {
+//			System.out.println("(SERVER) Creating input stream");
+//			client.createInputFromClient();
+//			System.out.println("(SERVER) Created input stream");
+//		} catch (IOException e2) {
+//			// TODO Auto-generated catch block
+//			e2.printStackTrace();
+//		}
+		
 		listenToClientThread[client.getID()] = new Thread("Listen to connected clients") {
 			public void run() {
 				while (!serverSocket.isClosed() && client.socketIsConnected()) {
+					
 					Object object;
 					try {
 						// Wait for the client to send some data

--- a/src/whs/yourchoice/server/Server.java
+++ b/src/whs/yourchoice/server/Server.java
@@ -1,21 +1,13 @@
-/**
- * Server.java		v0.7 28/02/2016
- * 
- * 
- */
-
 package whs.yourchoice.server;
 
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.net.ServerSocket;
 
 /**
  * Class for the server's back end handling communications to the clients. 
  * 
  * @author		user1092, guest501
- * @version		v07 28/02/2016
+ * @version		v08 06/04/2016
  */
 public class Server {
 	
@@ -26,6 +18,7 @@ public class Server {
 	private int currentClientNumber = 0;
 	private final int connectedClientsMaxNumber = 2;
 		
+	
 	/**
 	 * Constructor to create a new array of connected clients.
 	 */
@@ -50,6 +43,7 @@ public class Server {
 		}
 	}
 
+	
 	/**
 	 * Method to close socket to stop communications with a client.
 	 */
@@ -76,6 +70,7 @@ public class Server {
 			e.printStackTrace();
 		}
 	}
+	
 	
 	/**
 	 * Method to listen for new clients and accept their connection 
@@ -113,17 +108,6 @@ public class Server {
 							
 							currentClient = acceptClientConnection(currentClient);
 							currentClient.setID(currentClientNumber);
-//							try {
-//								System.out.println("(SERVER) Creating ouput stream");
-//								currentClient.createOutputToClient();
-//								System.out.println("(SERVER) Created ouput stream");
-//								System.out.println("(SERVER) Creating input stream");
-//								currentClient.createInputFromClient();
-//								System.out.println("(SERVER) Created input stream");
-//							} catch (IOException e) {
-//								// TODO Auto-generated catch block
-//								e.printStackTrace();
-//							}
 							manageClient(currentClient, currentClientNumber);
 							
 							if(currentClientNumber < connectedClientsMaxNumber - 1){
@@ -139,31 +123,14 @@ public class Server {
 						// Attempt to accept client
 						currentClient = acceptClientConnection(currentClient);
 						currentClient.setID(currentClientNumber);
-//						try {
-//							System.out.println("(SERVER) Creating ouput stream");
-//							currentClient.createOutputToClient();
-//							System.out.println("(SERVER) Created ouput stream");
-//							System.out.println("(SERVER) Creating input stream");
-//							currentClient.createInputFromClient();
-//							System.out.println("(SERVER) Created input stream");
-//						} catch (IOException e) {
-//							// TODO Auto-generated catch block
-//							e.printStackTrace();
-//						}
 						manageClient(currentClient, currentClientNumber);
-						
-//						try {
-//							currentClient.closeClientSocket();
-//						} catch (IOException e) {
-//							// TODO Auto-generated catch block
-//							e.printStackTrace();
-//						}
 					}
 				}
 			}
 		};	
 		listenThread.start();
 	}
+	
 	
 	/**
 	 * Method to accept a clients connection.
@@ -182,6 +149,7 @@ public class Server {
 		return currentClient;		
 	}
 	
+	
 	/**
 	 * Method to accept or refuse clients depending on if there is space
 	 * if accepted the client is then listened to for data requests.
@@ -192,12 +160,8 @@ public class Server {
 	private void manageClient(ConnectedClient currentClient, int clientNumber) {
 		try {
 			try {
-				System.out.println("(SERVER) Creating ouput stream");
 				currentClient.createOutputToClient();
-				System.out.println("(SERVER) Created ouput stream");
-				System.out.println("(SERVER) Creating input stream");
 				currentClient.createInputFromClient();
-				System.out.println("(SERVER) Created input stream");
 			} catch (IOException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
@@ -236,6 +200,7 @@ public class Server {
 		}
 	}
 
+	
 	/**
 	 * Method to send data to a client.
 	 * A connection must be made prior to using this method.
@@ -244,24 +209,6 @@ public class Server {
 	 * @param clientID	- This is the ID of the client the data should be sent to.
 	 */
 	protected void sendData(Object itemToSend, int clientID) {
-//		ObjectOutputStream outputToClient = null;
-//		
-//		// Create an object stream to send to client
-//		try {
-//			outputToClient = new ObjectOutputStream(clients[clientID].getClientSocket().getOutputStream());
-//		} catch (IOException e) {
-//			// TODO Auto-generated catch block
-//			e.printStackTrace();
-//		}
-//		
-//		// Write the object to the client
-//		try {
-//			outputToClient.writeObject(itemToSend);
-//		} catch (IOException e) {
-//			// TODO Auto-generated catch block
-//			e.printStackTrace();
-//		}
-		
 		try {
 			clients[clientID].getOutputToClient().writeObject(itemToSend);
 		} catch (IOException e) {
@@ -270,6 +217,7 @@ public class Server {
 		}
 		
 	}
+	
 
 	/**
 	 * Method to receive data from a client.
@@ -281,15 +229,9 @@ public class Server {
 	 * @throws ClassNotFoundException 
 	 */
 	protected Object receiveData(int clientID) throws IOException, ClassNotFoundException {
-//		ObjectInputStream inputFromClient = null;
-//				
-//		// Create an input stream from the connected client
-//		inputFromClient = new ObjectInputStream(clients[clientID].getClientSocket().getInputStream());
-//		
-//		// Return the object received from the client
-//		return inputFromClient.readObject();
 		return clients[clientID].getInputFromClient().readObject();
 	}
+	
 	
 	/**
 	 * Method to inform client that server is full.
@@ -297,24 +239,6 @@ public class Server {
 	 * @param client - This is the client to be informed
 	 */
 	private void informThatServerFull(ConnectedClient client) {
-//		ObjectOutputStream outputToClient = null;
-//		
-//		// Create an object stream to send to client
-//		try {
-//			outputToClient = new ObjectOutputStream(client.getClientSocket().getOutputStream());
-//		} catch (IOException e) {
-//			// TODO Auto-generated catch block
-//			e.printStackTrace();
-//		}
-//		
-//		// Write the object to the client
-//		try {
-//			outputToClient.writeObject(-1);
-//		} catch (IOException e) {
-//			// TODO Auto-generated catch block
-//			e.printStackTrace();
-//		}
-		
 		try {
 			client.getOutputToClient().writeObject(-1);
 		} catch (IOException e) {
@@ -330,6 +254,7 @@ public class Server {
 		}
 	}
 	
+	
 	/**
 	 * Method to listen to client for data requests
 	 * 
@@ -339,15 +264,6 @@ public class Server {
 		Thread[] listenToClientThread;
 		listenToClientThread = new Thread[connectedClientsMaxNumber];
 		
-//		try {
-//			System.out.println("(SERVER) Creating input stream");
-//			client.createInputFromClient();
-//			System.out.println("(SERVER) Created input stream");
-//		} catch (IOException e2) {
-//			// TODO Auto-generated catch block
-//			e2.printStackTrace();
-//		}
-		
 		listenToClientThread[client.getID()] = new Thread("Listen to connected clients") {
 			public void run() {
 				while (!serverSocket.isClosed() && client.socketIsConnected()) {
@@ -356,6 +272,7 @@ public class Server {
 					try {
 						// Wait for the client to send some data
 						object = receiveData(client.getID());
+						sendData(object, client.getID());
 					} catch (ClassNotFoundException e1) {
 						// TODO Auto-generated catch block
 						e1.printStackTrace();
@@ -375,4 +292,5 @@ public class Server {
 		listenToClientThread[client.getID()].start();
 	}
 
+	
 }

--- a/src/whs/yourchoice/server/ServerInterfacer.java
+++ b/src/whs/yourchoice/server/ServerInterfacer.java
@@ -1,8 +1,3 @@
-/**
- * ServerInterfacer.java		v0.4 23/02/2016
- * 
- * 
- */
 package whs.yourchoice.server;
 
 import java.io.IOException;
@@ -20,6 +15,7 @@ public class ServerInterfacer {
 
 	Server server;
 	
+	
 	/**
 	 * Constructor
 	 * 
@@ -29,12 +25,14 @@ public class ServerInterfacer {
 		server = new Server();
 	}
 	
+	
 	/**
 	 * Method to open socket to allow communications with a client.
 	 */
 	public void openSocket() {
 		server.openSocket();
 	}
+	
 	
 	/**
 	 * Method to close socket to stop communications with a client.
@@ -43,6 +41,7 @@ public class ServerInterfacer {
 		server.closeSocket();
 	}
 	
+	
 	/**
 	 * Method to listen for new clients and accept their connection 
 	 * then store their details in a connectedClients array.
@@ -50,6 +49,7 @@ public class ServerInterfacer {
 	public void checkAndAcceptClientConnections() {
 		server.checkAndAcceptClientConnections();
 	}
+	
 	
 	/**
 	 * Method to send data to a client.
@@ -61,6 +61,7 @@ public class ServerInterfacer {
 	public void sendData(Object itemToSend, int clientSocketNumber) {
 		server.sendData(itemToSend, clientSocketNumber);
 	}
+	
 	
 	/**
 	 * Method to receive data from a client.
@@ -74,5 +75,6 @@ public class ServerInterfacer {
 	public Object receiveData(int clientSocketNumber) throws ClassNotFoundException, IOException {
 		return server.receiveData(clientSocketNumber);
 	}
+	
 	
 }

--- a/src/whs/yourchoice/server/ServerTests.java
+++ b/src/whs/yourchoice/server/ServerTests.java
@@ -109,7 +109,14 @@ public class ServerTests {
 	public void serverShouldReceiveDataFromAnOpenSocket() {
 				
 		final Object itemToSend = "hello";
-				
+		
+		try {
+			Thread.sleep(500);
+		} catch (InterruptedException e2) {
+			// TODO Auto-generated catch block
+			e2.printStackTrace();
+		}
+		
 		/* Thread for server to listen to client
 		 * check the server receives the string hello
 		 */
@@ -124,7 +131,7 @@ public class ServerTests {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
 				}
-				System.out.println("BLUGHHH");
+				System.out.println("itemReceived: " + itemReceived);
 			}
 		};
 		listenThread.start();

--- a/src/whs/yourchoice/server/ServerTests.java
+++ b/src/whs/yourchoice/server/ServerTests.java
@@ -1,9 +1,3 @@
-/**
- * Server.java		v0.6 23/02/2016
- * 
- * 
- */
-
 package whs.yourchoice.server;
 
 import static org.junit.Assert.*;
@@ -22,7 +16,7 @@ import whs.yourchoice.client.ClientInterfacer;
  * Class for testing the server's back end handling communications to the clients. 
  * 
  * @author		user1092, guest501
- * @version		v0.6 23/02/2016
+ * @version		v0.7 06/04/2016
  */
 public class ServerTests {
 
@@ -41,6 +35,7 @@ public class ServerTests {
 	Object itemReceived = null;
 	Object recievedObject = null;
 	
+	
 	/**
 	 * Method run before every test to create a server, open its socket, and listen for a client.
 	 * Then a client is setup and its socket is opened. 
@@ -55,6 +50,7 @@ public class ServerTests {
 		client.openSocket(host, port);
 	}
 	
+	
 	/**
 	 * Method run after every test to close the client and server socket.
 	 */
@@ -65,6 +61,7 @@ public class ServerTests {
 		client.closeSocket();
 	}
 
+	
 	/**
 	 * Test that a server can send data on an open socket.
 	 */
@@ -102,6 +99,7 @@ public class ServerTests {
 		}				
 	}
 	
+	
 	/**
 	 * Test that a server can receive data from an open socket.
 	 */
@@ -123,10 +121,10 @@ public class ServerTests {
 		Thread listenThread = new Thread("Listen") {
 			public void run() {
 				try {
-					itemReceived = server.receiveData(0);
-				} catch (ClassNotFoundException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					// Can no longer do as server listens to client as soon as it connects
+					//itemReceived = server.receiveData(client.getID());
+					// Now Server will pass back the object as soon as it receives it
+					itemReceived = client.receiveData();
 				} catch (IOException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
@@ -150,6 +148,7 @@ public class ServerTests {
 		assertEquals(itemToSend, itemReceived);
 	}
 	
+	
 	/**
 	 * Test that a server can connect to multiple clients.
 	 */
@@ -157,7 +156,7 @@ public class ServerTests {
 	public void serverShouldConnectToMultipleClients() {
 		Object itemToSend = "STRING" ;
 		
-		ClientInterfacer client2 = new ClientInterfacer();
+		final ClientInterfacer client2 = new ClientInterfacer();
 		client2.openSocket(host, port);
 
 		server.checkAndAcceptClientConnections(); 
@@ -168,10 +167,10 @@ public class ServerTests {
 		Thread listenThread = new Thread("Listen") {
 			public void run() {
 				try {
-					itemReceived = server.receiveData(0);
-				} catch (ClassNotFoundException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					// Can no longer do as server listens to client as soon as it connects
+					//itemReceived = server.receiveData(client.getID());
+					// Now Server will pass back the object as soon as it receives it
+					itemReceived = client.receiveData();
 				} catch (IOException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
@@ -199,10 +198,10 @@ public class ServerTests {
 		Thread listenThread2 = new Thread("Listen") {
 			public void run() {
 				try {
-					itemReceived = server.receiveData(1);
-				} catch (ClassNotFoundException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					// Can no longer do as server listens to client as soon as it connects
+					//itemReceived = server.receiveData(client.getID());
+					// Now Server will pass back the object as soon as it receives it
+					itemReceived = client2.receiveData();
 				} catch (IOException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();


### PR DESCRIPTION
Client
Output stream now only created once, after the connection to server has been made
Input stream now only created once, after the connection to server has been made

ClientTests
server is no longer directly asked to receive data as this conflicts with structure of the server, instead the client listens for the object to be sent back

Server
Output stream no longer created every time an object is to be sent, instead the connectedClient creates one after the connection to server has been made
Input stream no longer created every time an object is to be received, instead the connectedClient creates one after the connection to server has been made

ConnectedClient
Output stream now contained within this class suitable methods have been made
Input stream now contained within this class suitable methods have been made

ClientTests
server is no longer directly asked to receive data as this conflicts with structure of the server, instead the client listens for the object to be sent back
